### PR TITLE
Use parameterized SQL insert

### DIFF
--- a/src/core/save_to_cache/mo.py
+++ b/src/core/save_to_cache/mo.py
@@ -3,7 +3,6 @@
 # @mail    : dylan_han@126.com    
 # @Time    : 2025/3/17 17:19
 import pymysql
-from pymysql.converters import escape_string
 
 class MatrixOne:
     def __init__(self):
@@ -55,19 +54,19 @@ file_name_embedding vecf32(1024)
         self.db.commit()
 
     def _insert_to_table(self, table, columns, values):
+        """Insert a row into ``table`` using parameterized SQL."""
         column = ",".join(columns)
-        value = ','.join(["'" + str(escape_string(str(unit))) + "'" for unit in values])
-        sql_instruction = "INSERT INTO {table} ({column}) VALUES ({data})".format(table=table, column=column,
-                                                                                  data=value)
-        self.cursor.execute(sql_instruction)
+        placeholders = ",".join(["%s"] * len(values))
+        sql_instruction = f"INSERT INTO {table} ({column}) VALUES ({placeholders})"
+        self.cursor.execute(sql_instruction, values)
         self.db.commit()
 
-    def _insert_to_table_abstract(self, columns, values,table):
+    def _insert_to_table_abstract(self, columns, values, table):
+        """Insert a row into ``table`` using parameterized SQL (abstracted)."""
         column = ",".join(columns)
-        value = ','.join(["'" + str(escape_string(str(unit))) + "'" for unit in values])
-        sql_instruction = "INSERT INTO {table} ({column}) VALUES ({data})".format(table=table, column=column,
-                                                                                  data=value)
-        self.cursor.execute(sql_instruction)
+        placeholders = ",".join(["%s"] * len(values))
+        sql_instruction = f"INSERT INTO {table} ({column}) VALUES ({placeholders})"
+        self.cursor.execute(sql_instruction, values)
         self.db.commit()
 
     def search_to_table(self, embed, column_name="chunks_embedding", method="l1_norm", table_name="handx"):

--- a/tests/test_mo.py
+++ b/tests/test_mo.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import types
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+
+
+class DummyCursor:
+    def __init__(self):
+        self.sql = None
+        self.params = None
+
+    def execute(self, sql, params=None):
+        self.sql = sql
+        self.params = params
+
+
+class DummyConnection:
+    def __init__(self):
+        self.cursor_obj = DummyCursor()
+        self.committed = False
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        self.committed = True
+
+
+# provide a minimal pymysql module for tests
+dummy_pymysql = types.ModuleType("pymysql")
+dummy_pymysql.connect = lambda *args, **kwargs: DummyConnection()
+sys.modules.setdefault("pymysql", dummy_pymysql)
+
+from src.core.save_to_cache.mo import MatrixOne
+
+
+@patch("pymysql.connect", return_value=DummyConnection())
+def test_insert_to_table(mock_connect):
+    mo = MatrixOne()
+    mo._insert_to_table("my_table", ["a", "b"], [1, "x"])
+    assert mo.cursor.sql == "INSERT INTO my_table (a,b) VALUES (%s,%s)"
+    assert mo.cursor.params == [1, "x"]
+    assert mo.db.committed
+
+
+@patch("pymysql.connect", return_value=DummyConnection())
+def test_insert_to_table_abstract(mock_connect):
+    mo = MatrixOne()
+    mo._insert_to_table_abstract(["a", "b"], [1, "x"], "my_table")
+    assert mo.cursor.sql == "INSERT INTO my_table (a,b) VALUES (%s,%s)"
+    assert mo.cursor.params == [1, "x"]
+    assert mo.db.committed


### PR DESCRIPTION
## Summary
- refactor database insertion helpers to use SQL placeholders
- remove unused escape_string import
- add basic unit tests for insert helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b3e14323c833182a101b19a88f420