### PR TITLE
Add unified document parser and semantic splitter

### DIFF
--- a/src/core/document_parser.py
+++ b/src/core/document_parser.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""Unified document parser and semantic splitter utilities."""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Dict, List, Any
+
+import pandas as pd
+
+from .docx_parser.docx_process import ParserDocx
+from .pdf_parser.pdf_process import ParserPDF
+from .models.semantic_splitter import SemanticParagraphSplitter
+from .models.embeddings import Embedding
+
+logger = logging.getLogger(__name__)
+
+
+class DocumentParser:
+    """Parse docx and pdf files into structured text and table data."""
+
+    def __init__(self) -> None:
+        self._docx = ParserDocx()
+        self._pdf = ParserPDF()
+
+    def _load_table(self, path: str) -> List[Dict[str, Any]]:
+        """Read an Excel table produced during parsing into a list of rows."""
+        try:
+            df = pd.read_excel(path)
+            return df.to_dict(orient="records")
+        except Exception:  # pragma: no cover - best effort loading
+            logger.exception("Failed to load table: %s", path)
+            return []
+
+    def parse_docx(self, file_path: str) -> Dict[str, Any]:
+        """Parse a docx file and return text blocks and table structures."""
+        result = {"text": [], "tables": []}
+        try:
+            for item in self._docx.read2docx(file_path):
+                if item.get("type") == "tables":
+                    result["tables"].append(self._load_table(item["content"]))
+                else:
+                    result["text"].append(item["content"])
+        except Exception as exc:  # pragma: no cover - input may be invalid
+            logger.exception("docx parsing failed: %s", exc)
+            result["error"] = str(exc)
+        return result
+
+    def parse_pdf(self, file_path: str) -> Dict[str, Any]:
+        """Parse a PDF file extracting text and table information."""
+        result = {"text": [], "tables": []}
+        try:
+            for item in self._pdf.parse(file_path):
+                style = item.get("style")
+                if style == "tables":
+                    result["tables"].append(self._load_table(item["content"]))
+                else:
+                    result["text"].append(item["content"])
+        except Exception as exc:  # pragma: no cover - input may be invalid
+            logger.exception("pdf parsing failed: %s", exc)
+            result["error"] = str(exc)
+        return result
+
+
+class SemanticSplitter:
+    """Split text into semantically coherent passages."""
+
+    def __init__(self, buffer_size: int = 1, threshold: int = 80, model: Any | None = None) -> None:
+        model = model or Embedding()
+        self._splitter = SemanticParagraphSplitter(model=model, buffer_size=buffer_size, threshold=threshold)
+
+    def split(self, text: str) -> List[str]:
+        return self._splitter.split_passages(text)
+
+
+def ingest_document(file_path: str) -> Dict[str, Any]:
+    """Example workflow that parses a document and splits its text."""
+    parser = DocumentParser()
+    splitter = SemanticSplitter()
+    ext = os.path.splitext(file_path)[1].lower()
+
+    if ext in {".doc", ".docx"}:
+        parsed = parser.parse_docx(file_path)
+    elif ext == ".pdf":
+        parsed = parser.parse_pdf(file_path)
+    else:
+        raise ValueError(f"Unsupported file type: {ext}")
+
+    paragraphs: List[str] = []
+    for text in parsed.get("text", []):
+        paragraphs.extend(splitter.split(text))
+
+    return {"paragraphs": paragraphs, "tables": parsed.get("tables", [])}
+
+
+if __name__ == "__main__":  # pragma: no cover - manual example
+    docx_example = os.path.join("data", "docx2", "AF-folder", "AF01.docx")
+    pdf_example = os.path.join("data", "pdf", "AF01.pdf")
+
+    for path in (docx_example, pdf_example):
+        res = ingest_document(path)
+        print(f"=== Results for {os.path.basename(path)} ===")
+        print("Paragraphs:")
+        for p in res["paragraphs"]:
+            print(f"- {p[:60]}")
+        print("Tables:", res["tables"])
+        print()

--- a/src/core/models/secure_query.py
+++ b/src/core/models/secure_query.py
@@ -1,0 +1,47 @@
+"""Example of parameterized SQL query to avoid injection."""
+from typing import List, Dict
+import sqlite3
+
+
+def secure_matrixone_query(query_embedding: str) -> List[Dict[str, str]]:
+    """Query the database using parameterized SQL to prevent injection.
+
+    Parameters
+    ----------
+    query_embedding: str
+        Serialized embedding string used for similarity search.
+
+    Returns
+    -------
+    List[Dict[str, str]]
+        Simplified query results.
+    """
+    conn = sqlite3.connect("matrixone.db")
+    cursor = conn.cursor()
+
+    sql = (
+        "SELECT id, file, file_name, chunks, title, indexs "
+        "FROM chunk_table "
+        "ORDER BY l1_norm(chunks_embedding - ?) "
+        "LIMIT 5;"
+    )
+
+    cursor.execute(sql, (query_embedding,))
+    rows = cursor.fetchall()
+    result: List[Dict[str, str]] = []
+    for row in rows:
+        id_, file, file_name, chunks, title, indexs = row
+        result.append(
+            {
+                "id": id_,
+                "source": file,
+                "file_name": file_name,
+                "title": title,
+                "index": indexs,
+                "chunks": chunks,
+            }
+        )
+
+    cursor.close()
+    conn.close()
+    return result

--- a/src/core/pdf_parser/pdf_parser_utils.py
+++ b/src/core/pdf_parser/pdf_parser_utils.py
@@ -1,0 +1,23 @@
+"""Utility functions describing and improving the PDF parser."""
+from typing import List
+
+
+def describe_pdf_parser() -> str:
+    """Return a brief description of how the PDF parser works and its role."""
+    return (
+        "PDF解析模块通过ParserPDF类读取并解析PDF文件，"
+        "利用pdfplumber提取文本、表格和图片OCR结果，"
+        "并将这些内容按顺序保存到缓存状态，供后续向量化处理。"
+        "出现异常时会记录日志并将工作流状态置为error，确保系统稳定。"
+    )
+
+
+def pdf_parser_improvement_suggestions() -> List[str]:
+    """Return detailed suggestions for improving the PDF parser and system."""
+    return [
+        "支持表格、图片及扫描件的更复杂解析，例如集成OCR识别表格结构", 
+        "使用异步或多进程提升批量PDF解析效率", 
+        "对解析结果引入缓存和版本控制，避免重复计算", 
+        "在异常情况下提供回退策略并增强错误信息", 
+        "结合性能监控与日志追踪，持续评估解析质量与速度", 
+    ]

--- a/tests/test_pdf_parser_module.py
+++ b/tests/test_pdf_parser_module.py
@@ -1,0 +1,88 @@
+import os
+import sys
+import time
+from shutil import copyfile
+import types
+from typing import List
+
+import pytest
+
+# provide dummy modules so heavy dependencies are not required during tests
+dummy_st = types.ModuleType("sentence_transformers")
+
+
+class DummyModel:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def encode(self, *args, **kwargs):
+        return [0.0]
+
+
+dummy_st.SentenceTransformer = DummyModel
+sys.modules.setdefault("sentence_transformers", dummy_st)
+
+dummy_pymysql = types.ModuleType("pymysql")
+dummy_pymysql.connect = lambda *a, **kw: None
+sys.modules.setdefault("pymysql", dummy_pymysql)
+
+dummy_modelscope = types.ModuleType("modelscope")
+dummy_modelscope.snapshot_download = lambda *a, **kw: ""
+sys.modules.setdefault("modelscope", dummy_modelscope)
+
+from src.core.knowledge_workflow import UserKnowledgeWorkflow
+
+
+class TestPdfParser:
+    """Tests for the PDF parsing workflow."""
+
+    def setup_method(self):
+        self.workflow = UserKnowledgeWorkflow()
+
+    def _state_for(self, pdf_path: str):
+        return {
+            "sessionId": "test_session",
+            "input_files": pdf_path,
+            "file_type": "AF",
+            "file_extension": "pdf",
+            "cache": False,
+            "error_messages": [],
+            "workflow_status": "running",
+            "messages": [],
+        }
+
+    def test_pdf_parse_success(self, tmp_path):
+        sample = os.path.join("data", "pdf", "AF01.pdf")
+        target = tmp_path / "sample.pdf"
+        copyfile(sample, target)
+        state = self._state_for(str(target))
+        result_state = self.workflow._parser_pdf(state)
+        assert result_state["workflow_status"] != "error"
+        assert result_state.get("cache_states")
+
+    def test_pdf_parse_failure(self, tmp_path, caplog):
+        corrupt = tmp_path / "corrupt.pdf"
+        corrupt.write_text("not a pdf")
+        state = self._state_for(str(corrupt))
+        with caplog.at_level("ERROR"):
+            result_state = self.workflow._parser_pdf(state)
+        assert result_state["workflow_status"] == "error"
+        assert any("PDF 文件解析失败" in rec.message for rec in caplog.records)
+
+    def test_pdf_parse_performance(self, tmp_path):
+        large = os.path.join("data", "pdf", "AZ06.pdf")
+        target = tmp_path / "large.pdf"
+        copyfile(large, target)
+        state = self._state_for(str(target))
+        start = time.time()
+        result_state = self.workflow._parser_pdf(state)
+        duration = time.time() - start
+        assert duration < 10
+        assert result_state["workflow_status"] != "error"
+
+    def test_pdf_parse_empty_file(self, tmp_path):
+        empty = tmp_path / "empty.pdf"
+        empty.write_bytes(b"")
+        state = self._state_for(str(empty))
+        result_state = self.workflow._parser_pdf(state)
+        assert result_state["workflow_status"] == "error"


### PR DESCRIPTION
## Summary
- create `DocumentParser` for unified docx and pdf parsing
- implement `SemanticSplitter` wrapper
- add `ingest_document` example workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b8dd42f8083319db79102b7ec4f6d